### PR TITLE
GAMECLOCK: Use "server time" instead of "game time" when in TF

### DIFF
--- a/cl_screen.c
+++ b/cl_screen.c
@@ -803,6 +803,8 @@ void SCR_DrawGameClock (void) {
 
 	if (cl.countdown || cl.standby)
 		strlcpy (str, SecondsToHourString(timelimit), sizeof(str));
+	else if (cl.teamfortress)
+		strlcpy (str, SecondsToHourString((int) abs(timelimit - cl.servertime)), sizeof(str));
 	else
 		strlcpy (str, SecondsToHourString((int) abs(timelimit - cl.gametime + scr_gameclock_offset.value)), sizeof(str));
 

--- a/common_draw.c
+++ b/common_draw.c
@@ -805,6 +805,8 @@ char* SCR_GetGameTime(int t)
 
 	if (cl.countdown || cl.standby)
 		strlcpy (str, SecondsToMinutesString(timelimit), sizeof(str));
+	else if (cl.teamfortress)
+		strlcpy (str, SecondsToMinutesString((int) abs(timelimit - cl.servertime)), sizeof(str));
 	else
 		strlcpy (str, SecondsToMinutesString((int) abs(timelimit - cl.gametime + *gameclockoffset)), sizeof(str));
 


### PR DESCRIPTION
Currently TF only, because I don't know how it will behave in other `gamedir`s and it may not be synced.